### PR TITLE
Add Dynamo Python snippet to identify empty user worksets

### DIFF
--- a/ACG Tools/snippets/Worksets_EmptyUserWorksets_PythonNode.py
+++ b/ACG Tools/snippets/Worksets_EmptyUserWorksets_PythonNode.py
@@ -1,0 +1,35 @@
+import clr
+
+clr.AddReference("RevitAPI")
+from Autodesk.Revit.DB import ElementWorksetFilter
+from Autodesk.Revit.DB import FilteredElementCollector
+from Autodesk.Revit.DB import FilteredWorksetCollector
+from Autodesk.Revit.DB import WorksetKind
+
+clr.AddReference("RevitServices")
+from RevitServices.Persistence import DocumentManager
+
+
+doc = DocumentManager.Instance.CurrentDBDocument
+
+# Collect only user-created worksets.
+user_worksets = list(
+    FilteredWorksetCollector(doc).OfKind(WorksetKind.UserWorkset)
+)
+
+empty_worksets = []
+
+for ws in user_worksets:
+    # Count only placed element instances (exclude element types).
+    instance_count = (
+        FilteredElementCollector(doc)
+        .WherePasses(ElementWorksetFilter(ws.Id, False))
+        .WhereElementIsNotElementType()
+        .GetElementCount()
+    )
+
+    if instance_count == 0:
+        empty_worksets.append(ws)
+
+# OUT returns Revit Workset objects that contain no element instances.
+OUT = empty_worksets


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Dynamo Python-node-ready script at `ACG Tools/snippets/Worksets_EmptyUserWorksets_PythonNode.py`
- iterate through all user-created worksets (`WorksetKind.UserWorkset`)
- return only worksets with zero placed element instances on them

## Notes
- output is a list of Revit `Workset` objects in `OUT`
- script is intended for direct copy/paste into a Dynamo Python node

## Validation
- verified script file added to package repository structure
- committed and pushed to `cursor/empty-workset-identification-e33d`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33d41284-f0e5-48f1-98cc-3c5a15c9f71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33d41284-f0e5-48f1-98cc-3c5a15c9f71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

