### PR TITLE
Add Dynamo script to group family instances by room

### DIFF
--- a/ACG Tools/python/Room_GroupFamilyInstancesByRoom.py
+++ b/ACG Tools/python/Room_GroupFamilyInstancesByRoom.py
@@ -5,7 +5,8 @@
 # Output:
 # OUT[0] = list of rooms that contain one or more furniture instances
 # OUT[1] = 2D list of furniture instances, aligned with OUT[0]
-# OUT[2] = list of rooms that do not contain any input furniture instances
+# OUT[2] = list of rooms that do not contain any input furniture instances,
+#          excluding room numbers already present in OUT[0]
 
 import clr
 
@@ -68,15 +69,24 @@ for wrapped_instance, revit_instance in instances:
 rooms_with_furniture = []
 furniture_in_rooms = []
 rooms_without_furniture = []
+room_numbers_with_furniture = set()
 
 for index, room_pair in enumerate(room_pairs):
     wrapped_room = room_pair[0]
+    revit_room = room_pair[1]
     room_furniture = furniture_by_room[index]
 
     if room_furniture:
         rooms_with_furniture.append(wrapped_room)
         furniture_in_rooms.append(room_furniture)
-    else:
+        room_numbers_with_furniture.add(revit_room.Number)
+
+for index, room_pair in enumerate(room_pairs):
+    wrapped_room = room_pair[0]
+    revit_room = room_pair[1]
+    room_furniture = furniture_by_room[index]
+
+    if not room_furniture and revit_room.Number not in room_numbers_with_furniture:
         rooms_without_furniture.append(wrapped_room)
 
 OUT = rooms_with_furniture, furniture_in_rooms, rooms_without_furniture

--- a/ACG Tools/python/Room_GroupFamilyInstancesByRoom.py
+++ b/ACG Tools/python/Room_GroupFamilyInstancesByRoom.py
@@ -1,0 +1,70 @@
+# Dynamo Python node inputs:
+# IN[0] = list of family instances
+# IN[1] = list of room instances
+#
+# Output:
+# Dictionary where each key is a room number and each value is the list of
+# input family instances whose LocationPoint is inside that room.
+
+import clr
+
+clr.AddReference("RevitAPI")
+from Autodesk.Revit.DB import LocationPoint
+
+clr.AddReference("RevitNodes")
+import Revit
+clr.ImportExtensions(Revit.Elements)
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def get_location_point(element):
+    if element is None or element.Location is None:
+        return None
+
+    location = element.Location
+    if isinstance(location, LocationPoint):
+        return location.Point
+
+    return None
+
+
+family_instances = as_list(IN[0])
+rooms = as_list(IN[1])
+
+# Keep the original Dynamo-wrapped family instances in the result values.
+instances = []
+for wrapped_instance in family_instances:
+    revit_instance = UnwrapElement(wrapped_instance)
+    if revit_instance is not None:
+        instances.append((wrapped_instance, revit_instance))
+
+revit_rooms = []
+for room in rooms:
+    revit_room = UnwrapElement(room)
+    if revit_room is not None:
+        revit_rooms.append(revit_room)
+
+result = {}
+
+for wrapped_instance, revit_instance in instances:
+    point = get_location_point(revit_instance)
+    if point is None:
+        continue
+
+    for room in revit_rooms:
+        if room.IsPointInRoom(point):
+            room_number = room.Number
+            if room_number not in result:
+                result[room_number] = []
+
+            result[room_number].append(wrapped_instance)
+            break
+
+OUT = result

--- a/ACG Tools/python/Room_GroupFamilyInstancesByRoom.py
+++ b/ACG Tools/python/Room_GroupFamilyInstancesByRoom.py
@@ -3,8 +3,9 @@
 # IN[1] = list of room instances
 #
 # Output:
-# Dictionary where each key is a room number and each value is the list of
-# input family instances whose LocationPoint is inside that room.
+# OUT[0] = list of rooms that contain one or more furniture instances
+# OUT[1] = 2D list of furniture instances, aligned with OUT[0]
+# OUT[2] = list of rooms that do not contain any input furniture instances
 
 import clr
 
@@ -35,36 +36,47 @@ def get_location_point(element):
     return None
 
 
-family_instances = as_list(IN[0])
+furniture_instances = as_list(IN[0])
 rooms = as_list(IN[1])
 
-# Keep the original Dynamo-wrapped family instances in the result values.
+# Keep the original Dynamo-wrapped elements in the output values.
 instances = []
-for wrapped_instance in family_instances:
+for wrapped_instance in furniture_instances:
     revit_instance = UnwrapElement(wrapped_instance)
     if revit_instance is not None:
         instances.append((wrapped_instance, revit_instance))
 
-revit_rooms = []
-for room in rooms:
-    revit_room = UnwrapElement(room)
+room_pairs = []
+for wrapped_room in rooms:
+    revit_room = UnwrapElement(wrapped_room)
     if revit_room is not None:
-        revit_rooms.append(revit_room)
+        room_pairs.append((wrapped_room, revit_room))
 
-result = {}
+furniture_by_room = [[] for room_pair in room_pairs]
 
 for wrapped_instance, revit_instance in instances:
     point = get_location_point(revit_instance)
     if point is None:
         continue
 
-    for room in revit_rooms:
+    for index, room_pair in enumerate(room_pairs):
+        room = room_pair[1]
         if room.IsPointInRoom(point):
-            room_number = room.Number
-            if room_number not in result:
-                result[room_number] = []
-
-            result[room_number].append(wrapped_instance)
+            furniture_by_room[index].append(wrapped_instance)
             break
 
-OUT = result
+rooms_with_furniture = []
+furniture_in_rooms = []
+rooms_without_furniture = []
+
+for index, room_pair in enumerate(room_pairs):
+    wrapped_room = room_pair[0]
+    room_furniture = furniture_by_room[index]
+
+    if room_furniture:
+        rooms_with_furniture.append(wrapped_room)
+        furniture_in_rooms.append(room_furniture)
+    else:
+        rooms_without_furniture.append(wrapped_room)
+
+OUT = rooms_with_furniture, furniture_in_rooms, rooms_without_furniture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Dynamo Python node script that groups input furniture/family instances by containing room.
- Return three outputs: rooms containing furniture, aligned 2D furniture lists, and rooms without furniture.
- Exclude rooms from the no-furniture output when their room number matches any room number already present in the furnished-room output.
- Use each furniture instance LocationPoint with Revit API Room.IsPointInRoom while preserving original Dynamo-wrapped elements in outputs.

## Validation
- `python3 -m py_compile "ACG Tools/python/Room_GroupFamilyInstancesByRoom.py"`

## Notes
- Revit/Dynamo runtime behavior was not executed in this Linux cloud environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecef49f9-87e6-4422-9604-16862477ff42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecef49f9-87e6-4422-9604-16862477ff42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

